### PR TITLE
Fix mirrored images being saved and tweeted.

### DIFF
--- a/photobooth.py
+++ b/photobooth.py
@@ -121,7 +121,14 @@ def takePhoto():
     if play_shutter_sound:
         shutter_sound.play()
 
+    # Unflip the photo so it is correct when taken
+    camera.hflip = False
+
+    # Take the photo
     camera.capture(path)
+
+    # Go back to flipped preview
+    camera.hflip = True
 
     # Go back to preview brightness
     camera.brightness = previewBrightness


### PR DESCRIPTION
Un-mirrors the preview (makes it easier for people to get situated) for photo taking so that any written words do not appear backwards. Just un-flips, takes the photo, then re-flips the preview.
